### PR TITLE
hatebu total count プラグインを追加する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'ruboty-wei', github: 'mzp/ruboty-wei'
 gem 'ruboty-trello_quote', github: 'standfirm/ruboty-trello_quote'
 gem 'ruboty-health_check', github: 'standfirm/ruboty-health_check'
 gem 'ruboty-aws', github: 'mzp/ruboty-aws'
+gem 'ruboty-hatebu_total_count', github: 'eitoball/ruboty-hatebu_total_count'
 
 
 gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/eitoball/ruboty-hatebu_total_count.git
+  revision: 12528a619ee99574d5ec93df032ed30520d74460
+  specs:
+    ruboty-hatebu_total_count (0.1.0)
+      ruboty
+
+GIT
   remote: git://github.com/mallowlabs/ruboty-nullpo.git
   revision: 7e1b2c9dc31a9004be1d29ede439ee587401aef9
   specs:
@@ -272,6 +279,7 @@ DEPENDENCIES
   ruboty-google_image
   ruboty-google_spreadsheet!
   ruboty-growthforecast!
+  ruboty-hatebu_total_count!
   ruboty-health_check!
   ruboty-lgtm
   ruboty-misawa!


### PR DESCRIPTION
[はてなブックマーク件数取得API](http://developer.hatena.ne.jp/ja/documents/bookmark/apis/getcount) を使って、サイトの総ブックマーク数をレポートする[プラグイン](https://github.com/eitoball/ruboty-hatebu_total_count)を作って、追加してみました。

簡単なspecは追加していますが、実際には動かしていないので、よろしくお願いします。

使用方法は、

```
/count http://www.google.com
```

です。
