### PR TITLE
mzp/disable-ssl gem を削除する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ ruby '2.4.5'
 gem 'ruboty'
 gem 'xrc'
 gem 'ruboty-slack_rtm'
-gem 'disable-ssl', github: 'mzp/disable-ssl'
 
 # ruboty plugins
 gem 'ruboty-alias'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,12 +46,6 @@ GIT
       ruboty
 
 GIT
-  remote: https://github.com/mzp/disable-ssl.git
-  revision: 37d754620e6832e98a1c92cfc214846303e7cbd3
-  specs:
-    disable-ssl (0.1.0)
-
-GIT
   remote: https://github.com/mzp/ruboty-growthforecast.git
   revision: 6c021a2c3f5f87d7f948f2465c7723cde0c37fc3
   specs:
@@ -365,7 +359,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  disable-ssl!
   foreman
   google-api-client (= 0.8.6)
   google_drive


### PR DESCRIPTION
```
May 26 20:30:05 sfruboty app/bot.1 WARNING: OpenSSL::SSL::VERIFY_PEER == OpenSSL::SSL::VERIFY_NONE
May 26 20:30:05 sfruboty app/bot.1 This dangerous monkey patch leaves you open to MITM attacks!
May 26 20:30:05 sfruboty app/bot.1 Try passing :verify_ssl => false instead.
```
という至極まっとうな警告がログに出ていたので削除します。

2015年に入ったことの gem の目的はわかりませんが、社内の開発ツールとかで証明書が用意できなった、とかがあるのかなーと思っています。