### PR TITLE
ruboty-slack_rtm をアップデートする

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.1)
       faraday (>= 0.7.4, < 1.0)
-    faye-websocket (0.10.7)
+    faye-websocket (0.10.9)
       eventmachine (>= 0.12.0)
       websocket-driver (>= 0.5.1)
     foreman (0.85.0)
@@ -314,7 +314,7 @@ GEM
       ruboty
     ruboty-replace (0.0.1)
       ruboty
-    ruboty-slack_rtm (3.1.0)
+    ruboty-slack_rtm (3.2.1)
       faraday (~> 0.11)
       ruboty (>= 1.1.4)
       slack-api (~> 1.6)
@@ -355,9 +355,9 @@ GEM
     websocket-client-simple (0.3.0)
       event_emitter
       websocket
-    websocket-driver (0.7.0)
+    websocket-driver (0.7.2)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.4)
     xrc (0.1.8)
       activesupport
 


### PR DESCRIPTION
最近 Ruboty がだんまりになることがあるので困っています。

現在の ruboty-slack_rtm のバージョンは 3.1.0 ですが、これを 3.2.1 まで上げます。
いくつか、再接続周りの修正が入っているので、改善が期待できると思っています。

gem のアップデートは以下のコマンドで実施しています。
```
$ bundle update ruboty-slack_rtm --conservative
```

### Changelog

* [added bind before restarting main_loop](https://github.com/rosylilly/ruboty-slack_rtm/commit/169fdce163b863ea28fc0c6191d57ae85ce7db33)
* [bind before restarting main_loop #37](https://github.com/rosylilly/ruboty-slack_rtm/pull/37)
* [Enable reply with thread #38](https://github.com/rosylilly/ruboty-slack_rtm/pull/38)
* [fix: duplicate frozen string #39](https://github.com/rosylilly/ruboty-slack_rtm/pull/39)
* [Enable to expect reconnect when exception occurred in Thread #40](https://github.com/rosylilly/ruboty-slack_rtm/pull/40)