### PR TITLE
use forked ruboty-timeline to suppress deprecation warning

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,6 @@ gem 'ruboty-sorena', github: 'standfirm/ruboty-sorena'
 gem 'ruboty-touban', github: 'hidakatsuya/ruboty-touban'
 gem 'ruboty-wei', github: 'mzp/ruboty-wei'
 gem 'ruboty-zoi', github: 'mallowlabs/ruboty-zoi'
-gem 'ruboty-timeline', github: 'standfirm/ruboty-timeline', branch: 'use-users.conversations-instead'
+gem 'ruboty-timeline', github: 'standfirm/ruboty-timeline', branch: 'use-uri_open'
 
 gem "foreman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,8 +108,8 @@ GIT
 
 GIT
   remote: https://github.com/standfirm/ruboty-timeline.git
-  revision: 19c54feed6763241f7461372fc5111af58c9bad9
-  branch: use-users.conversations-instead
+  revision: 7786abaf1f30b20562d4e22383b4689e8d83c578
+  branch: use-uri_open
   specs:
     ruboty-timeline (0.1.0)
       ruboty
@@ -279,7 +279,7 @@ GEM
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
-    slack-notifier (2.3.2)
+    slack-notifier (2.4.0)
     slop (4.9.1)
     thor (0.19.4)
     trailblazer-option (0.1.1)


### PR DESCRIPTION
ruboty-timeline由来で出ている `warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open` というdeprecation warningを抑えるため、[修正したものを用意しました](https://github.com/standfirm/ruboty-timeline/commits/use-uri_open)。元の `use-users.conversations-instead` からbranch切ってます。slack-notifierが一緒に上がってますが、Ruby 3対応なので上げたほうが良いと思います。
https://github.com/slack-notifier/slack-notifier/blob/main/changelog.md