### PR TITLE
HerokuにコンテナデプロイができるようにDockerfileとheroku.ymlを作成した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.7.8-alpine3.16
+
+WORKDIR /app
+
+RUN apk update && apk add g++ git make
+
+COPY Gemfile Gemfile.lock /app/
+
+RUN bundle install
+
+COPY . /app
+
+CMD ["bundle", "exec", "ruboty"]

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    bot: Dockerfile
+run:
+  bot: bundle exec ruboty


### PR DESCRIPTION
Herokuスタックではなく、Dockerを利用したコンテナデプロイに変更します。
[heroku.yml を使用して Docker イメージをビルドする | Heroku Dev Center](https://devcenter.heroku.com/ja/articles/build-docker-images-heroku-yml)